### PR TITLE
fix: Remove error injection code from ListingEndpoints (Permanent fix for recurring incidents)

### DIFF
--- a/octo-pets-sample/backend/Endpoints/ListingEndpoints.cs
+++ b/octo-pets-sample/backend/Endpoints/ListingEndpoints.cs
@@ -4,34 +4,7 @@ using Octopets.Backend.Repositories.Interfaces;
 namespace Octopets.Backend.Endpoints;
 
 public static class ListingEndpoints
-{    
-    // Method to simulate memory exhaustion by allocating ~1GB of memory
-    private static void AReallyExpensiveOperation()
-    {
-        // Create lists to hold large amounts of data
-        var memoryHogs = new List<byte[]>();
-
-        // Allocate memory in chunks until we reach approximately 1GB
-        // Each iteration allocates 100MB
-        for (int i = 0; i < 10; i++)
-        {
-            // Allocate 100MB per iteration (100 * 1024 * 1024 = 104,857,600 bytes)
-            var largeArray = new byte[100 * 1024 * 1024];
-
-            // Fill with random data to ensure memory is actually allocated
-            new Random().NextBytes(largeArray);
-
-            // Add to list to prevent garbage collection
-            memoryHogs.Add(largeArray);
-
-            // Add a small delay to let the effect be more visible
-            Thread.Sleep(100);
-        }
-
-        // Retain the reference to prevent garbage collection
-        GC.KeepAlive(memoryHogs);
-    }
-
+{
     public static void MapListingEndpoints(this WebApplication app)
     {
         var group = app.MapGroup("/api/listings")
@@ -48,20 +21,8 @@ public static class ListingEndpoints
         .WithOpenApi();
 
         // GET listing by id
-        group.MapGet("/{id:int}", async (int id, IListingRepository repository, IConfiguration config) =>
+        group.MapGet("/{id:int}", async (int id, IListingRepository repository) =>
         {
-            // INTENTIONAL BUG: This will cause 500 errors when ERRORS flag is set to true
-            // Only throw exception or simulate memory issues if ERRORS flag is set to true
-            if (config.GetValue<bool>("ERRORS"))
-            {
-                // Simulate null reference exception - causes immediate HTTP 500
-                string nullString = null;
-                var length = nullString.Length; // NullReferenceException for SRE Agent detection
-                
-                // Alternative: Memory exhaustion (commented out for now)
-                // AReallyExpensiveOperation();
-            }
-
             var listing = await repository.GetByIdAsync(id);
             return listing is null ? Results.NotFound() : Results.Ok(listing);
         })


### PR DESCRIPTION
## Summary

Permanently removes the intentional error injection code from `ListingEndpoints.cs` that has caused **multiple production incidents today** (2026-04-22).

## Changes

- **Removed** `NullReferenceException` trigger gated by `ERRORS` config flag from `GET /api/listings/{id}`
- **Removed** `AReallyExpensiveOperation()` method (~1GB memory allocation simulation)
- **Removed** unused `IConfiguration` dependency from the GET by ID handler

## Incident History (2026-04-22)

This error injection code has caused **3+ separate incidents today**, all following the same pattern:

| Time (UTC) | Alert | Impact |
|---|---|---|
| ~09:55 | avgresponse on octopetsapi | 80% request failure rate, NullReferenceException |
| ~10:25 | avgresponse on octopetsapi | 73.7% failure rate, Sev3 |
| **11:39** | **Latency on octopetsfe** | **500s on /api/listings/{id} propagating as latency to frontend** |

Each time, the mitigation was to set `ERRORS=false` on the container app — but the flag keeps getting re-enabled. This PR removes the code entirely so the `ERRORS` flag has no effect.

## Root Cause

The `GET /api/listings/{id}` endpoint contained code that checks an `ERRORS` configuration flag. When `true`, it throws a `NullReferenceException`:

```csharp
if (config.GetValue<bool>("ERRORS"))
{
    string nullString = null;
    var length = nullString.Length; // NullReferenceException → HTTP 500
}
```

This causes HTTP 500s on the backend that propagate through the frontend nginx proxy as elevated response times.

## Testing

- The fix retains all legitimate listing retrieval logic using the repository pattern
- `GET /api/listings` (list all) — unaffected
- `GET /api/listings/{id}` (get by ID) — now always performs the correct database lookup
- POST/PUT/DELETE endpoints — unaffected (they don't use the `ERRORS` flag)

## Related Issues

Fixes #1, Fixes #2, Fixes #3, Fixes #4

---
Created by [Azure SRE Agent](https://sre.azure.com/agents/subscriptions/7b53f31b-558b-4108-b0c2-8fc0c7ea7435/resourceGroups/rg-sre-demo/providers/Microsoft.App/agents/ecognity/views/thread/8ebdf6fe-cbbb-49f5-89d9-48db93bb44f1)